### PR TITLE
Automatically Apply Public Sans to v2.14.x

### DIFF
--- a/docs/en/001_index.md
+++ b/docs/en/001_index.md
@@ -83,19 +83,12 @@ After build you will notice a `waratah-branding` directory in the project root. 
 
 Development environments will automatically load non-minified assets.
 
-### 2. Add font customisation
+### 2. Optional: add CSS customisation
 
-> This is a once-only step during project creation. for v0.3 / nswds v2.14 only
+Customisation can be added to `waratah-branding/frontend/src/app.scss` via your own SCSS/CSS.
 
-Add the following to `waratah-branding/frontend/src/app.scss`:
+See [Branding](./100_branding.md) documentation for more information.
 
-```css
-:root {
-  --nsw-font-family: 'Public Sans', sans-serif;
-}
-```
-
-This will [override the Montserrat font shipped](https://github.com/digitalnsw/nsw-design-system-v2/blob/master/src/global/scss/settings/_theme.scss#L35)
 
 ### 3. Add theme configuration
 

--- a/src/Extensions/DesignSystemAssetExtension.php
+++ b/src/Extensions/DesignSystemAssetExtension.php
@@ -89,17 +89,10 @@ class DesignSystemAssetExtension extends Extension {
      */
     protected function requireFonts() {
 
-        if($this->getConfigurationValue('branding_version') >= 3) {
-            Requirements::css(
-                "https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,700;1,400&display=swap",
-                "screen"
-            );
-        } else {
-            Requirements::css(
-                "https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,600;1,400;1,600&display=swap",
-                "screen"
-            );
-        }
+        Requirements::css(
+            "https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,700;1,400&display=swap",
+            "screen"
+        );
 
         Requirements::css(
             "https://fonts.googleapis.com/icon?family=Material+Icons&display=block",

--- a/themes/nswds/app/frontend/src/scss/app.scss
+++ b/themes/nswds/app/frontend/src/scss/app.scss
@@ -7,6 +7,9 @@
 // NSW Design System
 @import 'node_modules/nsw-design-system/src/main';
 
+// Apply typography eg Public Sans
+@import './components/waratah/typography';
+
 // Silverstripe components - MFA, userforms, editor field
 @import './components/silverstripe/silverstripe';
 

--- a/themes/nswds/app/frontend/src/scss/components/waratah/_mixins.scss
+++ b/themes/nswds/app/frontend/src/scss/components/waratah/_mixins.scss
@@ -1,6 +1,9 @@
 /**
  * nswdpc/waratah mixins for wrth- extensions
  */
+
+$font-stack: var(--nsw-font-family);
+
 @mixin wrth-button {
   @include font-stack('heading');
   @include font-size('sm');

--- a/themes/nswds/app/frontend/src/scss/components/waratah/_typography.scss
+++ b/themes/nswds/app/frontend/src/scss/components/waratah/_typography.scss
@@ -1,0 +1,4 @@
+// Apply typography, eg specify font family
+:root {
+  --nsw-font-family: 'Public Sans', sans-serif;
+}

--- a/themes/nswds/app/static/editor.css
+++ b/themes/nswds/app/static/editor.css
@@ -1,4 +1,8 @@
-@import url("https://fonts.googleapis.com/css?family=Montserrat:300,400,400i,500,700,700i&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,700;1,400&amp;display=swap");
+
+:root {
+  --nsw-font-family: 'Public Sans', sans-serif;
+}
 
 body {
   overflow-x: hidden;
@@ -14,7 +18,7 @@ button,
 input,
 select,
 textarea {
-  font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"
+  font-family: var(--nsw-font-family);
 }
 
 table {
@@ -42,7 +46,7 @@ td {
 }
 
 a.nsw-button.nsw-button--primary {
-	font-family: Montserrat,Arial,sans-serif;
+	font-family: var(--nsw-font-family);
 	-moz-osx-font-smoothing: grayscale;
 	font-weight: 600;
 	font-size: 1rem;
@@ -70,7 +74,7 @@ a.nsw-button.nsw-button--primary {
 }
 
 a.nsw-button.nsw-button--secondary {
-	font-family: Montserrat,Arial,sans-serif;
+	font-family: var(--nsw-font-family);
 	-moz-osx-font-smoothing: grayscale;
 	font-weight: 600;
 	font-size: 1rem;
@@ -98,7 +102,7 @@ a.nsw-button.nsw-button--secondary {
 }
 
 a.nsw-button.nsw-button--danger {
-	font-family: Montserrat,Arial,sans-serif;
+	font-family: var(--nsw-font-family);
 	-moz-osx-font-smoothing: grayscale;
 	font-weight: 600;
 	font-size: 1rem;


### PR DESCRIPTION
## Background

Previously, projects were required to add Public Sans as a per-project customisation. This change sets up Public Sans from the start to override the Monserrat shipped as default in v2.14.x of nsw-design-system.

The change already exists in master/v1.x (NSWDS v3)

## Changes

+ Update documentation
+ Replace `branding_version` test with default Public Sans inclusion
+ Add typography settings to  override nsw-design-system
+ editor.css support

