### PR TITLE
add lazy loading to imgs

### DIFF
--- a/themes/nswds/templates/Includes/MediaHolderChildren.ss
+++ b/themes/nswds/templates/Includes/MediaHolderChildren.ss
@@ -56,7 +56,7 @@
                 <div class="nsw-card nsw-card--highlight<% if $Up.Brand %> nsw-card--{$Up.Brand.XML}<% end_if %>">
                     <% if $Image %>
                         <div class="nsw-card__image">
-                            <img src="{$Image.FocusFillMax(400,200).URL}" alt="{$Image.AltText.XML}">
+                            <img src="{$Image.FocusFillMax(400,200).URL}" alt="{$Image.AltText.XML}" loading="lazy">
                         </div>
                     <% end_if %>
                     <div class="nsw-card__content">

--- a/themes/nswds/templates/NSWDPC/Elemental/Models/Banner/ElementBanner.ss
+++ b/themes/nswds/templates/NSWDPC/Elemental/Models/Banner/ElementBanner.ss
@@ -29,7 +29,7 @@
             <% end_if %>
             <div class="nsw-hero-banner__box"<% if $BannerStyle == "title-content" || $BannerStyle == "call-to-action" %> role="presentation"<% end_if %>>
                 <% if $BannerStyle == "title-content-image" || $BannerStyle == "call-to-action-image" %>
-                    <img class="nsw-hero-banner__image" src="{$Image.FocusFillMax(1000,1125).URL}" alt="{$Image.AltText}">
+                    <img class="nsw-hero-banner__image" src="{$Image.FocusFillMax(1000,1125).URL}" alt="{$Image.AltText}" loading="lazy">
                 <% else %>
                     <div class="nsw-hero-banner__bg"></div>
                 <% end_if %>

--- a/themes/nswds/templates/NSWDPC/Elemental/Models/Mediawesome/Includes/ItemList.ss
+++ b/themes/nswds/templates/NSWDPC/Elemental/Models/Mediawesome/Includes/ItemList.ss
@@ -10,7 +10,7 @@
         <div class="nsw-card nsw-card--highlight<% if $Up.Brand %> nsw-card--{$Up.Brand.XML}<% end_if %>">
             <% if $Image %>
                 <div class="nsw-card__image">
-                    <img src="{$Image.FocusFillMax(400,200).URL}" alt="{$Image.AltText.XML}">
+                    <img src="{$Image.FocusFillMax(400,200).URL}" alt="{$Image.AltText.XML}" loading="lazy">
                 </div>
             <% end_if %>
             <div class="nsw-card__content">

--- a/themes/nswds/templates/NSWDPC/Waratah/ElementDecoratedContent/Includes/Card.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/ElementDecoratedContent/Includes/Card.ss
@@ -3,11 +3,11 @@
     <% if $Up.Up.CardStyle == "title-image-abstract" %>
         <% if $Image %>
             <div class="nsw-card__image">
-                <img src="$Image.FocusFillMax(600,400).URL" alt="{$Image.Title.XML}">
+                <img src="$Image.FocusFillMax(600,400).URL" alt="{$Image.Title.XML}" loading="lazy">
             </div>
         <% else_if $SiteTree.Image %>
             <div class="nsw-card__image">
-                <img src="$SiteTree.Image.FocusFillMax(600,400).URL" alt="{$SiteTree.Image.Title.XML}">
+                <img src="$SiteTree.Image.FocusFillMax(600,400).URL" alt="{$SiteTree.Image.Title.XML}" loading="lazy">
             </div>
         <% end_if %>
     <% end_if %>

--- a/themes/nswds/templates/NSWDPC/Waratah/ElementDecoratedContent/Includes/ProfileImage.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/ElementDecoratedContent/Includes/ProfileImage.ss
@@ -1,3 +1,3 @@
 <div class="profile-photo">
-    <img src="{$Image.FocusFillMax(400,400).URL}" class="img-fluid img-profile" alt="{$Image.AltText.XML}">
+    <img src="{$Image.FocusFillMax(400,400).URL}" class="img-fluid img-profile" alt="{$Image.AltText.XML}" loading="lazy">
 </div>

--- a/themes/nswds/templates/NSWDPC/Waratah/ElementalLinks/Includes/Cards.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/ElementalLinks/Includes/Cards.ss
@@ -10,11 +10,11 @@
                     <% if $Up.Up.CardStyle == "title-image-abstract" %>
                         <% if $Image %>
                             <div class="nsw-card__image">
-                                <img src="$Image.FocusFillMax(600,400).URL" alt="{$Image.AltText.XML}">
+                                <img src="$Image.FocusFillMax(600,400).URL" alt="{$Image.AltText.XML}" loading="lazy">
                             </div>
                         <% else_if $SiteTree.Image %>
                             <div class="nsw-card__image">
-                                <img src="$SiteTree.Image.FocusFillMax(600,400).URL" alt="{$SiteTree.Image.AltText.XML}">
+                                <img src="$SiteTree.Image.FocusFillMax(600,400).URL" alt="{$SiteTree.Image.AltText.XML}" loading="lazy">
                             </div>
                         <% end_if %>
                     <% end_if %>

--- a/themes/nswds/templates/NSWDPC/Waratah/ElementalList/Includes/Cards.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/ElementalList/Includes/Cards.ss
@@ -12,11 +12,11 @@
                     <% if $Up.Up.CardStyle == "title-image-abstract" %>
                         <% if $ContentImage %>
                         <div class="nsw-card__image">
-                            <img src="{$ContentImage.FocusFillMax(600,400).URL}" alt="{$ContentImage.AltText.XML}">
+                            <img src="{$ContentImage.FocusFillMax(600,400).URL}" alt="{$ContentImage.AltText.XML}" loading="lazy">
                         </div>
                         <% else_if $Image %>
                             <div class="nsw-card__image">
-                                <img src="{$Image.FocusFillMax(600,400).URL}" alt="{$Image.AltText.XML}">
+                                <img src="{$Image.FocusFillMax(600,400).URL}" alt="{$Image.AltText.XML}" loading="lazy">
                             </div>
                         <% end_if %>
                     <% end_if %>

--- a/themes/nswds/templates/nswds/Includes/Card.ss
+++ b/themes/nswds/templates/nswds/Includes/Card.ss
@@ -34,7 +34,7 @@
                          {$Card_Image.ScaleHeight(200)}
                     <% end_if %>
                 <% else %>
-                    <img src="{$Card_ImageURL.XML}" height="200">
+                    <img src="{$Card_ImageURL.XML}" height="200" loading="lazy">
                 <% end_if %>
             </div>
             <% end_if %>

--- a/themes/nswds/templates/nswds/Includes/ContentBlock.ss
+++ b/themes/nswds/templates/nswds/Includes/ContentBlock.ss
@@ -7,12 +7,12 @@
         <% if $ContentBlock_Image || $ContentBlock_IconImage || ContentBlock_IconSVG || $ContentBlock_ImageURL %>
             <div class="nsw-content-block__image">
             <% if $ContentBlock_Image %>
-                <img src="$ContentBlock_Image.FocusFillMax(600,400).URL" alt="{$ContentBlock_Image.AltText.XML}">
+                <img src="$ContentBlock_Image.FocusFillMax(600,400).URL" alt="{$ContentBlock_Image.AltText.XML}" loading="lazy">
             <% else_if $ContentBlock_ImageURL %>
-                <img src="{$ContentBlock_ImageURL.XML}" width="600" height="400" alt="{$ContentBlock_Image.AltText.XML}">
+                <img src="{$ContentBlock_ImageURL.XML}" width="600" height="400" alt="{$ContentBlock_Image.AltText.XML}" loading="lazy">
             <% else_if $ContentBlock_IconImage %>
                 <div class="nsw-content-block__icon">
-                <img src="{$ContentBlock_IconImage.FocusFillMax(64,64).URL}" alt="{$ContentBlock_IconImage.AltText.XML}">
+                <img src="{$ContentBlock_IconImage.FocusFillMax(64,64).URL}" alt="{$ContentBlock_IconImage.AltText.XML}" loading="lazy">
                 </div>
             <% else_if $ContentBlock_IconSVG %>
                 <div class="nsw-content-block__icon">

--- a/themes/nswds/templates/nswds/Includes/ListItem.ss
+++ b/themes/nswds/templates/nswds/Includes/ListItem.ss
@@ -50,11 +50,11 @@
 
     <% if $ListItem_Image %>
     <div class="nsw-list-item__image">
-        <img src="{$ListItem_Image.Fill(500,500).URL}" alt="{$ListItem_Image.Title.XML}">
+        <img src="{$ListItem_Image.Fill(500,500).URL}" alt="{$ListItem_Image.Title.XML}" loading="lazy">
     </div>
     <% else_if $ListItem_ImageURL %>
     <div class="nsw-list-item__image">
-        <img src="{$ListItem_ImageURL.XML}" alt="{$ListItem_ImageAlt.XML}">
+        <img src="{$ListItem_ImageURL.XML}" alt="{$ListItem_ImageAlt.XML}" loading="lazy">
     </div>
     <% end_if %>
 

--- a/themes/nswds/templates/nswds/Includes/Media.ss
+++ b/themes/nswds/templates/nswds/Includes/Media.ss
@@ -12,7 +12,7 @@
         {$Media_Image.ScaleHeight($Media_ImageHeight)}
     <% else %>
         <%-- both are 0 --%>
-        <img src="{$Media_Image.URL}" alt="{$Media_Image.AltText}">
+        <img src="{$Media_Image.URL}" alt="{$Media_Image.AltText}" loading="lazy">
     <% end_if %>
 
     <% if Media_LinkToImage %></a><% end_if %>


### PR DESCRIPTION
I've added the `loading="lazy"` attribute to a number of img elements throughout the theme to help improve the page initial load speed