### PR TITLE
NEW: add LongTitle to allow longer title with line break(s)

### DIFF
--- a/src/Extensions/SiteConfigExtension.php
+++ b/src/Extensions/SiteConfigExtension.php
@@ -47,7 +47,10 @@ class SiteConfigExtension extends DataExtension
         'WelcomeToCountry' => 'Text',
 
         // Accessibility
-        'EnableTextToSpeech' => 'Boolean'
+        'EnableTextToSpeech' => 'Boolean',
+
+        // Long Title, allow wrapping
+        'LongTitle' => 'Text'
 
     ];
 
@@ -277,6 +280,18 @@ class SiteConfigExtension extends DataExtension
                     _t('nswds.ENABLE_TEXT_TO_SPEECH', 'Enable text to speech')
                 )
             ]
+        );
+
+        // Provide alternative long title to allow for long names, used sparingly
+        $fields->insertAfter(
+            'Title',
+            TextareaField::create(
+                'LongTitle',
+                _t('nswds.TITLE_WITH_BREAKS', 'Longer form of site title')
+            )->setRows(2)
+            ->setDescription(
+                 _t('nswds.TITLE_WITH_BREAKS_DESCRIPTION', 'Used in header, if provided')
+            )
         );
     }
 

--- a/themes/nswds/templates/nswds/Includes/Waratah.ss
+++ b/themes/nswds/templates/nswds/Includes/Waratah.ss
@@ -20,7 +20,7 @@
     <%-- masterband has title and tagline --%>
     <div class="nsw-header__name">
         <% with SiteConfig %>
-        <div class="nsw-header__title">{$Title.XML}</div>
+        <div class="nsw-header__title"><% if $LongTitle %>{$LongTitle}<% else %>{$Title.XML}<% end_if %></div>
         <% if $Tagline %>
         <div class="nsw-header__description">{$Tagline.XML}</div>
         <% end_if %>


### PR DESCRIPTION
## Changes

+ Support custom line breaks on longer agency names - #9
+ Favour "long title" over "Title" if provide, but only in the header component