### PR TITLE
Modal mobile viewport improvements

### DIFF
--- a/themes/nswds/app/frontend/src/scss/components/waratah/_micromodal.scss
+++ b/themes/nswds/app/frontend/src/scss/components/waratah/_micromodal.scss
@@ -58,6 +58,8 @@
     @include breakpoint('sm', 'max-width') {
       padding: rem(32px);
       width: auto;
+
+      .wrth-mm__content,
       .wrth-mm__footer,
       .wrth-mm__header {
         /* alignment chutzpah */

--- a/themes/nswds/app/frontend/src/scss/components/waratah/_micromodal.scss
+++ b/themes/nswds/app/frontend/src/scss/components/waratah/_micromodal.scss
@@ -49,13 +49,25 @@
 
   &__container {
     max-width: 1170px;
-    max-height: 100vh;
-    width: 50%;
-  }
-
-  &__actions {
     display: flex;
-    justify-content: flex-end;
+    flex-direction: column;
+    justify-content: center;
+    height: 100%;
+    width: 70%;
+
+    @include breakpoint('sm', 'max-width') {
+      padding: rem(32px);
+      width: auto;
+      .wrth-mm__footer,
+      .wrth-mm__header {
+        /* alignment chutzpah */
+        margin-top: auto;
+      }
+
+      .wrth-mm__footer button {
+        width: 100%;
+      }
+    }
   }
 
   &__content {

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/Modal.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/Modal.ss
@@ -5,12 +5,6 @@
 
         <div class="wrth-mm__container" role="dialog" aria-modal="true" aria-labelledby="{$Modal_ModalID}-title">
 
-            <div class="wrth-mm__actions nsw-block">
-                <button class="wrth-mm__close nsw-icon-button nsw-button--light-outline" aria-label="<%t wrth.CLOSE_MODAL 'Close this dialog' %>" data-micromodal-close>
-                    <% include nswds/Icon Icon_Icon='close' %>
-                </button>
-            </div>
-
             <% if $Modal_ShowTitle && $Modal_Title %>
             <div class="wrth-mm__header nsw-block">
                 <h2 id="{$Modal_ModalID}-title">{$Modal_Title.XML}</h2>


### PR DESCRIPTION
## Changes

+ On sm viewport, move close button to thumb friendly position
+ remove [x] close action in header
+ Apply positive margin space to align modal elements (https://www.w3.org/TR/css-flexbox-1/#auto-margins)