### PR TITLE
Add better support for full width containers

### DIFF
--- a/themes/nswds/app/frontend/src/scss/app.scss
+++ b/themes/nswds/app/frontend/src/scss/app.scss
@@ -20,6 +20,7 @@
 @import './components/waratah/brand';
 @import './components/waratah/canvas';
 @import './components/waratah/card';
+@import './components/waratah/grid';
 @import './components/waratah/filters';
 @import './components/waratah/form';
 @import './components/waratah/icon-button';

--- a/themes/nswds/app/frontend/src/scss/components/waratah/_grid.scss
+++ b/themes/nswds/app/frontend/src/scss/components/waratah/_grid.scss
@@ -1,0 +1,8 @@
+/**
+ * Container extras
+ */
+.wrth-container {
+  &-fluid {
+    max-width: none;
+  }
+}

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/ElementHolder.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/ElementHolder.ss
@@ -20,9 +20,9 @@
     <section class="<% if $Background %>{$Background}<% end_if %><% if $VerticalSpacing %> nsw-section--{$VerticalSpacing}<% end_if %><% if $StyleVariant %> {$StyleVariant}<% end_if %><% if $ExtraClass %> {$ExtraClass}<% end_if %>" id="{$Anchor}" data-type="{$ElementShortName}">
 
         <%-- landing page elements can have containers and backgrounds --%>
-        <% if $AddContainer %><div class="nsw-container"><% end_if %>
+        <div class="<% if $AddContainer %>nsw-container<% else %>nsw-container wrth-container-fluid<% end_if %>">
             {$Element}
-        <% if $AddContainer %></div><% end_if %>
+        </div>
 
     </section>
 


### PR DESCRIPTION
Similar to Bootstrap container-fluid, a fluid container just overrides the max-width on nsw-container and allows the element to take up the full width of the parent element, retaining padding set in nsw-container.