### PR TITLE
Readonly field improvements

### DIFF
--- a/themes/nswds/templates/SilverStripe/Forms/ReadonlyField.ss
+++ b/themes/nswds/templates/SilverStripe/Forms/ReadonlyField.ss
@@ -1,6 +1,6 @@
-<span id="$ID" <% if $extraClass %>class="$extraClass"<% end_if %>>
-	$Value
-</span>
+<div id="{$ID}" class="readonly nsw-bg--off-white nsw-border--2 nsw-border--grey-04 nsw-p-sm">
+    {$Value}
+</div>
 <% if $IncludeHiddenField %>
-	<input $getAttributesHTML("id", "type") id="hidden-{$ID}" type="hidden" />
+    <input $getAttributesHTML("id", "type") id="hidden-{$ID}" type="hidden" />
 <% end_if %>


### PR DESCRIPTION
## Changes

+ (enh) ensure the readonly field is rendered as a block element + avoid inheriting the field's default classes, use some utility classes instead

## Example:

```php
ReadonlyField::create(
    'Sample',
    'Suspendisse potenti',
    'Duis congue mi in lectus lobortis, ut vestibulum magna varius. Sed facilisis orci at odio dignissim, ut gravida lorem facilisis. Sed nec dapibus tellus. Donec sed ullamcorper metus.'
)->setDescription(
    'Nullam fringilla sed ante a tempor. Curabitur lorem ante, imperdiet eget convallis in, tristique nec ligula.'
)->setRightTitle(
    'Pellentesque laoreet libero sed tincidunt scelerisque. Sed sapien turpis, pellentesque vel libero ut, mattis luctus magna.'
),
```

Result ...

![image](https://user-images.githubusercontent.com/69664712/202337463-534e7c1f-9df5-4bfa-904e-c8b2dbf00c8e.png)


Possible issues:

+ There is no --border-1 in the DS utility class.
+ Should it try to look like a field at all?

