### PR TITLE
Remove composite field padding in date input

### DIFF
--- a/themes/nswds/templates/NSWDPC/DateInputs/DateCompositeField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/DateCompositeField_holder.ss
@@ -10,14 +10,10 @@
 
     <% include nswds/FormFieldMessage FormFieldMessage_IsCompact=1, FormFieldMessage_Message=$Message, FormFieldMessage_MessageType=$MessageType, FormFieldMessage_MessageCast=$MessageCast %>
 
-    <div class="nsw-section nsw-section--half-padding nsw-section--off-white">
-        <div class="nsw-container">
-            <div class="inputs">
-                {$Field}
-            </div>
-            <% if $FormatExample %><span class="nsw-form__helper">{$FormatExample.XML}</span><% end_if %>
-        </div>
+    <div class="inputs">
+        {$Field}
     </div>
+    <% if $FormatExample %><span class="nsw-form__helper">{$FormatExample.XML}</span><% end_if %>
 
     <% include NSWDPC/Waratah/Forms/RightTitle %>
 


### PR DESCRIPTION
The field is a composite field, when it is included in a composite field itself the padding added by the section/container creates a nesting effect.

This was changed back in https://github.com/nswdpc/waratah/commit/59246f4d09a0f58d7412d4bde3e9f37bac8337e6#diff-3bf0e9d733d3bb3ab5509af0a314f0601894b489bbe120eb17037a5799a92321 as part of the form component update.



## Changes

+ (enh) ensure date input composite field doesn't include extra padding


## Result

Not nested in a composite field:

![image](https://user-images.githubusercontent.com/69664712/202338940-f6737adc-f006-42f4-bb25-d82510dca732.png)

Nested in a composite field:

![image](https://user-images.githubusercontent.com/69664712/202339012-4e8e04a8-920b-4f89-b14e-31ce6a192e91.png)


vs:

![image](https://user-images.githubusercontent.com/69664712/202339114-ba61489e-a80c-4e0b-a77c-f9d3b7d615b7.png)
