### PR TITLE
Drop/replace footer in template

### DIFF
--- a/themes/nswds/templates/Security.ss
+++ b/themes/nswds/templates/Security.ss
@@ -25,7 +25,5 @@
 
 <% include NSWDPC/Waratah/Security/MainBody Layout=$Layout %>
 
-<% include nswds/Footer %>
-
 </body>
 </html>

--- a/themes/nswds/templates/Security.ss
+++ b/themes/nswds/templates/Security.ss
@@ -25,5 +25,7 @@
 
 <% include NSWDPC/Waratah/Security/MainBody Layout=$Layout %>
 
+<% include NSWDPC/Waratah/Security/Footer %>
+
 </body>
 </html>


### PR DESCRIPTION
The footer is not relevant in this context, but allow projects to provide an include file for special cases.