### PR TITLE
Readonly field and Composite Field styling fix and improvement

### DIFF
--- a/themes/nswds/templates/SilverStripe/Forms/CompositeField_holder.ss
+++ b/themes/nswds/templates/SilverStripe/Forms/CompositeField_holder.ss
@@ -40,21 +40,17 @@
 
             <% include NSWDPC/Waratah/Forms/Legend %>
 
-            <section class="nsw-section nsw-section--half-padding nsw-section--off-white">
+            <div class="nsw-p-left-xs nsw-p-bottom-lg">
 
-                <div class="nsw-container">
+                <% include NSWDPC/Waratah/Forms/Description %>
 
-                    <% include NSWDPC/Waratah/Forms/Description %>
-
-                    <div class="field">
-                    {$Field}
-                    </div>
-
-                    <% include NSWDPC/Waratah/Forms/RightTitle %>
-
+                <div class="field">
+                {$Field}
                 </div>
 
-            </section>
+                <% include NSWDPC/Waratah/Forms/RightTitle %>
+
+            </div>
 
         </fieldset>
 

--- a/themes/nswds/templates/SilverStripe/Forms/ReadonlyField.ss
+++ b/themes/nswds/templates/SilverStripe/Forms/ReadonlyField.ss
@@ -1,4 +1,4 @@
-<div id="{$ID}" class="readonly nsw-bg--off-white nsw-border--2 nsw-border--grey-04 nsw-p-sm">
+<div id="{$ID}" class="readonly nsw-bg--off-white nsw-border nsw-border-1 nsw-border-grey-03 nsw-border-radius nsw-p-sm">
     {$Value}
 </div>
 <% if $IncludeHiddenField %>

--- a/themes/nswds/templates/SilverStripe/Forms/SelectionGroup.ss
+++ b/themes/nswds/templates/SilverStripe/Forms/SelectionGroup.ss
@@ -5,15 +5,13 @@
     <% include NSWDPC/Waratah/Forms/Legend %>
 
     <% loop $FieldSet %>
-        <section class="nsw-section nsw-section--half-padding nsw-section--off-white">
-            <div class="nsw-container">
-                {$RadioButton}
-                <label class="nsw-form__radio-label" for="{$Up.ID}_{$Pos}">{$RadioLabel}</label>
-                <div class="nsw-form__group">
-                {$Field}
-                </div>
+        <div class="nsw-p-left-xs nsw-p-bottom-lg">
+            {$RadioButton}
+            <label class="nsw-form__radio-label" for="{$Up.ID}_{$Pos}">{$RadioLabel}</label>
+            <div class="nsw-form__group">
+            {$Field}
             </div>
-        </section>
+        </div>
     <% end_loop %>
 
 </fieldset>


### PR DESCRIPTION
## Changes

nswds 3.6.0 introduced some utility classes to assist styling

+ Update readonly field styling to use utility classes, fixes an issue where the field was outline with the --nsw-brand-accent colour
+ Replace CompositeField background colour with spacing to avoid contrast clashes
+ Update SelectionGroup field holder in line with CompositeField holder change