### PR TITLE
Slimselect: fixes/improvements

### DIFF
--- a/themes/nswds/app/frontend/src/js/components/slimselect.js
+++ b/themes/nswds/app/frontend/src/js/components/slimselect.js
@@ -6,17 +6,26 @@ export default function initSlimSelect() {
      */
     document.querySelectorAll('div:not(.nsw-multi-select) > select[multiple]').forEach( (listbox) => {
       try {
-        let placeholder = listbox.getAttribute('placeholder');
+        let placeholderText = listbox.getAttribute('placeholder');
         let searchText = listbox.dataset.searchText;
-        new SlimSelect({
+        let searchPlaceholder = listbox.dataset.searchPlaceholder;
+        let settings = {
+          searchHighlight: true,
+          allowDeselect: true,
+          closeOnSelect: false
+        };
+        if(placeholderText) {
+          settings.placeholderText = placeholderText;
+        }
+        if(searchText) {
+          settings.searchText = searchText;
+        }
+        if(searchPlaceholder) {
+          settings.searchPlaceholder = searchPlaceholder;
+        }
+        let slim = new SlimSelect({
             select: listbox,
-            settings: {
-              placeholder: placeholder ? placeholder : 'Select one or more items',
-              searchText: searchText ? searchText : 'Sorry couldn\'t find anything..',
-              searchHighlight: true,
-              allowDeselect: true,
-              closeOnSelect: false
-            }
+            settings: settings
         });
       } catch (e) {
         console.error(e);

--- a/themes/nswds/app/frontend/src/js/components/slimselect.js
+++ b/themes/nswds/app/frontend/src/js/components/slimselect.js
@@ -1,34 +1,54 @@
 import SlimSelect from 'slim-select';
 
+export function applySlimSelect(listbox) {
+  try {
+    let placeholderText = listbox.getAttribute('placeholder');
+    let searchText = listbox.dataset.hasOwnProperty('searchText') ? listbox.dataset.searchText : '';
+    let searchPlaceholder = listbox.dataset.hasOwnProperty('searchPlaceholder') ? listbox.dataset.searchPlaceholder : '';
+    let minSelected = listbox.dataset.hasOwnProperty('minSelected') ? listbox.dataset.minSelected : null;
+    let maxSelected = listbox.dataset.hasOwnProperty('maxSelected') ? listbox.dataset.maxSelected : null;
+    let matching = listbox.dataset.hasOwnProperty('matching') ? listbox.dataset.matching : 'default';
+    let settings = {
+      searchHighlight: true,
+      allowDeselect: true,
+      closeOnSelect: false
+    };
+    if(placeholderText) {
+      settings.placeholderText = placeholderText;
+    }
+    if(searchText) {
+      settings.searchText = searchText;
+    }
+    if(searchPlaceholder) {
+      settings.searchPlaceholder = searchPlaceholder;
+    }
+    if(minSelected >= 0) {
+      settings.minSelected = minSelected;
+    }
+    if(maxSelected >= 0) {
+      settings.maxSelected = maxSelected;
+    }
+    let events = {};
+    if(matching == 'start') {
+      events.searchFilter = function(option, search) {
+        return option.text.toLowerCase().substr(0, search.length) === search.toLowerCase();
+      };
+    }
+    let slim = new SlimSelect({
+        select: listbox,
+        settings: settings,
+        events: events
+    });
+  } catch (e) {
+    console.error(e);
+  }
+};
+
 export default function initSlimSelect() {
     /**
      * Apply slim-select to any multiple select inputs
      */
     document.querySelectorAll('div:not(.nsw-multi-select) > select[multiple]').forEach( (listbox) => {
-      try {
-        let placeholderText = listbox.getAttribute('placeholder');
-        let searchText = listbox.dataset.searchText;
-        let searchPlaceholder = listbox.dataset.searchPlaceholder;
-        let settings = {
-          searchHighlight: true,
-          allowDeselect: true,
-          closeOnSelect: false
-        };
-        if(placeholderText) {
-          settings.placeholderText = placeholderText;
-        }
-        if(searchText) {
-          settings.searchText = searchText;
-        }
-        if(searchPlaceholder) {
-          settings.searchPlaceholder = searchPlaceholder;
-        }
-        let slim = new SlimSelect({
-            select: listbox,
-            settings: settings
-        });
-      } catch (e) {
-        console.error(e);
-      }
+      applySlimSelect(listbox);
     });
 }

--- a/themes/nswds/app/frontend/src/scss/components/thirdparty/_slimselect.scss
+++ b/themes/nswds/app/frontend/src/scss/components/thirdparty/_slimselect.scss
@@ -26,7 +26,7 @@
       }
 
       .ss-value-delete {
-        border-left: 1px solid var(--nsw-white);
+        border-left: none;
       }
     }
 


### PR DESCRIPTION
## Changes

+ Fix: setting name `placeholderText`, not `placeholder`
+ Use data-* attribute values as equivalent settings values (searchPlaceholder, minSelected, maxSelected)
+ Support max/minSelected settings
+ Support searchPlaceholder setting
+ Add a 'matching' dataset property to control how values are matched in the `searchFilter` event
+ Export a function `applySlimSelect` for use elsewhere
+ UI: drop border on delete button
