### PR TITLE
Update HTMLReadonlyField and CompositeField templates

### DIFF
--- a/themes/nswds/templates/SilverStripe/Forms/CompositeField_holder.ss
+++ b/themes/nswds/templates/SilverStripe/Forms/CompositeField_holder.ss
@@ -40,7 +40,7 @@
 
             <% include NSWDPC/Waratah/Forms/Legend %>
 
-            <div class="nsw-p-left-xs nsw-p-bottom-lg">
+            <div class="nsw-p-left-xs">
 
                 <% include NSWDPC/Waratah/Forms/Description %>
 

--- a/themes/nswds/templates/SilverStripe/Forms/HTMLReadonlyField_holder.ss
+++ b/themes/nswds/templates/SilverStripe/Forms/HTMLReadonlyField_holder.ss
@@ -1,3 +1,4 @@
+<div id="$HolderID" class="nsw-form__group<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
 <% if $FormFieldHint == 'callout' %>
     <%-- render as callout --%>
     <div class="nsw-callout">
@@ -26,3 +27,4 @@
 <% else %>
     {$Field}
 <% end_if %>
+</div>

--- a/themes/nswds/templates/SilverStripe/Forms/HTMLReadonlyField_holder.ss
+++ b/themes/nswds/templates/SilverStripe/Forms/HTMLReadonlyField_holder.ss
@@ -1,4 +1,4 @@
-<div id="$HolderID" class="nsw-form__group<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+<div id="{$HolderID}" class="nsw-form__group<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
 <% if $FormFieldHint == 'callout' %>
     <%-- render as callout --%>
     <div class="nsw-callout">


### PR DESCRIPTION
Maintain spacing consistency in forms.

## Changes

+ Remove the lg bottom padding from composite field
+ Wrap the HTMLReadonlyField in the form group holder element