### PR TITLE
Update datetime inputs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "nswdpc/silverstripe-feedback-assist": "^0.2.3",
         "nswdpc/silverstripe-field-hint": "^0.1",
         "nswdpc/silverstripe-grid-helpers": "^0.2",
-        "nswdpc/silverstripe-datetime-inputs": "^0.1.1",
+        "nswdpc/silverstripe-datetime-inputs": "<1",
         "nswdpc/silverstripe-notices": "^0.1"
     },
     "require-dev": {

--- a/themes/nswds/app/frontend/package-lock.json
+++ b/themes/nswds/app/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "micromodal": "^0.4.10",
-        "nsw-design-system": "^3.12.0",
+        "nsw-design-system": "^3.16.0",
         "slim-select": "^2.4.5"
       },
       "devDependencies": {
@@ -6244,9 +6244,9 @@
       }
     },
     "node_modules/nsw-design-system": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/nsw-design-system/-/nsw-design-system-3.12.0.tgz",
-      "integrity": "sha512-pzA4OV6meEskUkrD7OifAKLY1p8QIq72OBtHkrt42C4HyU62PF4a8KGYrox9z0DcQSFlI68bBmfaVupM84CPCg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/nsw-design-system/-/nsw-design-system-3.16.0.tgz",
+      "integrity": "sha512-jPLifC65vFx6RkvhT08pdrIJCtW4aNqEb1a/Ltpy3iSetPnniUKLdmY5AQSQfJr0PzEPwZRmXHc9QTrsDEB3nw==",
       "dependencies": {
         "@floating-ui/dom": "^1.2.8"
       }
@@ -14059,9 +14059,9 @@
       }
     },
     "nsw-design-system": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/nsw-design-system/-/nsw-design-system-3.12.0.tgz",
-      "integrity": "sha512-pzA4OV6meEskUkrD7OifAKLY1p8QIq72OBtHkrt42C4HyU62PF4a8KGYrox9z0DcQSFlI68bBmfaVupM84CPCg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/nsw-design-system/-/nsw-design-system-3.16.0.tgz",
+      "integrity": "sha512-jPLifC65vFx6RkvhT08pdrIJCtW4aNqEb1a/Ltpy3iSetPnniUKLdmY5AQSQfJr0PzEPwZRmXHc9QTrsDEB3nw==",
       "requires": {
         "@floating-ui/dom": "^1.2.8"
       }

--- a/themes/nswds/app/frontend/package.json
+++ b/themes/nswds/app/frontend/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "micromodal": "^0.4.10",
-    "nsw-design-system": "^3.12.0",
+    "nsw-design-system": "^3.16.0",
     "slim-select": "^2.4.5"
   },
   "devDependencies": {

--- a/themes/nswds/app/frontend/src/scss/app.scss
+++ b/themes/nswds/app/frontend/src/scss/app.scss
@@ -20,6 +20,7 @@
 @import './components/waratah/brand';
 @import './components/waratah/canvas';
 @import './components/waratah/card';
+@import './components/waratah/date';
 @import './components/waratah/grid';
 @import './components/waratah/feature';
 @import './components/waratah/filters';

--- a/themes/nswds/app/frontend/src/scss/components/waratah/_date.scss
+++ b/themes/nswds/app/frontend/src/scss/components/waratah/_date.scss
@@ -1,0 +1,24 @@
+/**
+ * Date related styles, e.g date inputs
+ */
+
+.nsw-form {
+   &__date {
+     /* apply styles to date input component */
+     &-wrapper {
+       width: 100%;
+       gap: 0.5rem;
+       margin: 0;
+       & > div {
+         padding: 0rem;
+         flex: 1;
+       }
+     }
+     &-input {
+       width: auto;
+       &--large {
+         width: auto;
+       }
+     }
+   }
+}

--- a/themes/nswds/templates/NSWDPC/DateInputs/DateCompositeField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/DateCompositeField_holder.ss
@@ -1,7 +1,6 @@
-<div id="{$HolderID}" class="nsw-form__group wrth-form__composite<% if $ExtraClass %> {$ExtraClass}<% end_if %>" data-is-composite="1">
+<div id="{$HolderID}" class="nsw-form__group nsw-form__date wrth-form__composite<% if $ExtraClass %> {$ExtraClass}<% end_if %>" data-is-composite="1">
 
-    <label class="nsw-form__label left">{$Title.XML}</label>
-
+    <label class="nsw-form__label<% if $Required %> nsw-form__required<% end_if %>" for="{$Children.First.ID}">{$Title.XML}</label>
     <% include NSWDPC/Waratah/Forms/Description %>
 
     <% if $FieldWarning %>
@@ -10,7 +9,7 @@
 
     <% include nswds/FormFieldMessage FormFieldMessage_IsCompact=1, FormFieldMessage_Message=$Message, FormFieldMessage_MessageType=$MessageType, FormFieldMessage_MessageCast=$MessageCast %>
 
-    <div class="inputs">
+    <div class="nsw-form__date-wrapper">
         {$Field}
     </div>
     <% if $FormatExample %><span class="nsw-form__helper">{$FormatExample.XML}</span><% end_if %>

--- a/themes/nswds/templates/NSWDPC/DateInputs/DayOfMonthField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/DayOfMonthField_holder.ss
@@ -1,0 +1,15 @@
+<div id="$HolderID" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+
+    <% if $Title %><label class="nsw-form__label nsw-form__label--small left<% if $Required %> nsw-form__required<% end_if %>" for="{$ID}">{$Title}</label><% end_if %>
+
+    <% include NSWDPC/Waratah/Forms/Description %>
+
+    <div class="field">
+    {$Field}
+    </div>
+
+    <% include nswds/FormFieldMessage FormFieldMessage_IsCompact=1, FormFieldMessage_Message=$Message, FormFieldMessage_MessageType=$MessageType, FormFieldMessage_MessageCast=$MessageCast %>
+
+    <% include NSWDPC/Waratah/Forms/RightTitle %>
+
+</div>

--- a/themes/nswds/templates/NSWDPC/DateInputs/DayOfMonthField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/DayOfMonthField_holder.ss
@@ -1,4 +1,4 @@
-<div id="$HolderID" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+<div id="{$HolderID}" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
 
     <% if $Title %><label class="nsw-form__label nsw-form__label--small left<% if $Required %> nsw-form__required<% end_if %>" for="{$ID}">{$Title}</label><% end_if %>
 

--- a/themes/nswds/templates/NSWDPC/DateInputs/MonthNumberField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/MonthNumberField_holder.ss
@@ -1,0 +1,15 @@
+<div id="$HolderID" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+
+    <% if $Title %><label class="nsw-form__label nsw-form__label--small left<% if $Required %> nsw-form__required<% end_if %>" for="{$ID}">{$Title}</label><% end_if %>
+
+    <% include NSWDPC/Waratah/Forms/Description %>
+
+    <div class="field">
+    {$Field}
+    </div>
+
+    <% include nswds/FormFieldMessage FormFieldMessage_IsCompact=1, FormFieldMessage_Message=$Message, FormFieldMessage_MessageType=$MessageType, FormFieldMessage_MessageCast=$MessageCast %>
+
+    <% include NSWDPC/Waratah/Forms/RightTitle %>
+
+</div>

--- a/themes/nswds/templates/NSWDPC/DateInputs/MonthNumberField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/MonthNumberField_holder.ss
@@ -1,4 +1,4 @@
-<div id="$HolderID" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+<div id="{$HolderID}" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
 
     <% if $Title %><label class="nsw-form__label nsw-form__label--small left<% if $Required %> nsw-form__required<% end_if %>" for="{$ID}">{$Title}</label><% end_if %>
 

--- a/themes/nswds/templates/NSWDPC/DateInputs/TimeField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/TimeField_holder.ss
@@ -1,0 +1,15 @@
+<div id="$HolderID" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+
+    <% if $Title %><label class="nsw-form__label nsw-form__label--small left<% if $Required %> nsw-form__required<% end_if %>" for="{$ID}">{$Title}</label><% end_if %>
+
+    <% include NSWDPC/Waratah/Forms/Description %>
+
+    <div class="field">
+    {$Field}
+    </div>
+
+    <% include nswds/FormFieldMessage FormFieldMessage_IsCompact=1, FormFieldMessage_Message=$Message, FormFieldMessage_MessageType=$MessageType, FormFieldMessage_MessageCast=$MessageCast %>
+
+    <% include NSWDPC/Waratah/Forms/RightTitle %>
+
+</div>

--- a/themes/nswds/templates/NSWDPC/DateInputs/TimeField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/TimeField_holder.ss
@@ -1,4 +1,4 @@
-<div id="$HolderID" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+<div id="{$HolderID}" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
 
     <% if $Title %><label class="nsw-form__label nsw-form__label--small left<% if $Required %> nsw-form__required<% end_if %>" for="{$ID}">{$Title}</label><% end_if %>
 

--- a/themes/nswds/templates/NSWDPC/DateInputs/YearField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/YearField_holder.ss
@@ -1,0 +1,15 @@
+<div id="$HolderID" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+
+    <% if $Title %><label class="nsw-form__label nsw-form__label--small left<% if $Required %> nsw-form__required<% end_if %>" for="{$ID}">{$Title}</label><% end_if %>
+
+    <% include NSWDPC/Waratah/Forms/Description %>
+
+    <div class="field">
+    {$Field}
+    </div>
+
+    <% include nswds/FormFieldMessage FormFieldMessage_IsCompact=1, FormFieldMessage_Message=$Message, FormFieldMessage_MessageType=$MessageType, FormFieldMessage_MessageCast=$MessageCast %>
+
+    <% include NSWDPC/Waratah/Forms/RightTitle %>
+
+</div>

--- a/themes/nswds/templates/NSWDPC/DateInputs/YearField_holder.ss
+++ b/themes/nswds/templates/NSWDPC/DateInputs/YearField_holder.ss
@@ -1,4 +1,4 @@
-<div id="$HolderID" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+<div id="{$HolderID}" class="nsw-form__date-input nsw-form__date-input--large<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
 
     <% if $Title %><label class="nsw-form__label nsw-form__label--small left<% if $Required %> nsw-form__required<% end_if %>" for="{$ID}">{$Title}</label><% end_if %>
 

--- a/themes/nswds/templates/nswds/Includes/DateInput.ss
+++ b/themes/nswds/templates/nswds/Includes/DateInput.ss
@@ -1,0 +1,19 @@
+<%-- this is a placeholder component template, see DateInputs templates/module for a functional component with validation --%>
+<div class="nsw-form">
+  <div class="nsw-form__group">
+    <fieldset class="nsw-form__date">
+      <legend>
+        <span class="nsw-form__label">{$Title}</span>
+        <% if $Description %><span class="nsw-form__helper">{$Description}</span><% end_if %>
+      </legend>
+      <div class="nsw-form__date-wrapper">
+        {$DayField}
+        {$MonthField}
+        {$YearField}
+        <% if $TimeField %>
+        {$TimeField}
+        <% end_if %>
+      </div>
+    </fieldset>
+  </div>
+</div>


### PR DESCRIPTION
See #87 

## Changes

+ Update nsw-design-system to 3.16.0 to support date inputs component
+ Add templates for nswdpc/silverstripe-datetime-inputs fields with nswds classes
+ Apply override CSS to ensure fields take up container width, for consistency
+ Set version upper boundary  for nswdpc/silverstripe-datetime-inputs requirement