### PR TITLE
Grid composite field

### DIFF
--- a/docs/en/004_advanced_forms.md
+++ b/docs/en/004_advanced_forms.md
@@ -1,0 +1,18 @@
+# Advanced forms
+
+## CompositeField grid options
+
+CompositeFields support a variety of simple grid options, allowing layout control over their child fields.
+
+> At small screen sizes, all child fields stack and the grid option value is ignored.
+
+### Options
+
+> Use the `setGridOption` method to set a grid option on a composite field.
+> Each option is a value selectable in CSS via the [data-grid-option] selector
+
++ `equal-width-fields`: child fields will be equal spaced across the row. This works well with 2 to 4 child fields
++ `2-across`: child fields appear in a 2xN grid, each field is 1/2 width of the container
++ `3-across`: child fields appear in a 3xN grid, each field is 1/3 width of the container
+
+Any `HTMLReadonlyField` in a composite field is considered a break and will be given a `flex-basis` of 100%.

--- a/src/Extensions/FormFieldExtension.php
+++ b/src/Extensions/FormFieldExtension.php
@@ -3,6 +3,7 @@
 namespace NSWDPC\Waratah\Extensions;
 
 use SilverStripe\Core\Extension;
+use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\ListboxField;
 
@@ -62,6 +63,23 @@ class FormFieldExtension extends Extension
             'Title' => ''
         ];
         return $this->owner->FieldHolder( $properties );
+    }
+
+    /**
+     * Set a grid option via a data attribute, with one of the supported grid options
+     */
+    public function setGridOption(string $gridOption) {
+        if(!($this->owner instanceof CompositeField)) {
+            throw new \RuntimeException("Only composite fields can have a grid option set");
+        }
+        return $this->owner->setAttribute('data-grid-option', $gridOption);
+    }
+
+    /**
+     * Template variable for returning a grid option. See CompositeField_holder
+     */
+    public function GridOption() : ?string {
+        return $this->owner->getAttribute('data-grid-option');
     }
 
 }

--- a/themes/nswds/app/frontend/src/scss/components/waratah/_form.scss
+++ b/themes/nswds/app/frontend/src/scss/components/waratah/_form.scss
@@ -44,4 +44,70 @@ form {
     @extend .nsw-button--danger;
   }
 
+
+  @include breakpoint("sm") {
+    /**
+     * Composite field grid options
+     */
+    .wrth-form__composite {
+
+      &[data-grid-option] {
+        .field.cp {
+          display: flex;
+          flex-direction: row;
+          flex-wrap: wrap;
+          align-items: flex-end;
+          justify-content: space-between;
+          gap: rem(16px);
+
+          > * {
+            margin-top: 0;
+            flex: 1 1 100%;
+          }
+
+          /**
+           * A flex break is full width
+           */
+          .wrth-flex__break {
+            flex-basis: 100%;
+          }
+        }
+      }
+
+      &[data-grid-option="equal-width-fields"] {
+        .field.cp {
+          > * {
+            flex: 1;
+          }
+        }
+      }
+
+      &[data-grid-option="2-across"] {
+        .field.cp {
+
+          align-items: flex-start;
+
+          > * {
+            /* grow shrink basis */
+            flex: 0 1 calc(50% - rem(16px));
+          }
+        }
+      }
+
+      &[data-grid-option="3-across"] {
+        .field.cp {
+
+          align-items: flex-start;
+
+          > * {
+            /* grow shrink basis */
+            flex: 0 1 calc((100%/3) - rem(16px));
+          }
+        }
+      }
+
+    }
+
+  }
+
 }

--- a/themes/nswds/templates/SilverStripe/Forms/CompositeField_holder.ss
+++ b/themes/nswds/templates/SilverStripe/Forms/CompositeField_holder.ss
@@ -1,5 +1,5 @@
 
-<div id="{$HolderID}" class="nsw-form__group wrth-form__composite<% if $Zebra %> {$Zebra}<% end_if %><% if $ParentExtraClass %> {$ParentExtraClass}<% end_if %>" data-is-composite="1">
+<div id="{$HolderID}"<% if $GridOption %> data-grid-option="{$GridOption}"<% end_if %> class="nsw-form__group wrth-form__composite<% if $Zebra %> {$Zebra}<% end_if %><% if $ParentExtraClass %> {$ParentExtraClass}<% end_if %>" data-is-composite="1">
 
     <% if $FormFieldHint == 'callout' %>
 
@@ -44,7 +44,7 @@
 
                 <% include NSWDPC/Waratah/Forms/Description %>
 
-                <div class="field">
+                <div class="field cp">
                 {$Field}
                 </div>
 

--- a/themes/nswds/templates/SilverStripe/Forms/HTMLReadonlyField_holder.ss
+++ b/themes/nswds/templates/SilverStripe/Forms/HTMLReadonlyField_holder.ss
@@ -1,4 +1,4 @@
-<div id="{$HolderID}" class="nsw-form__group<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
+<div id="{$HolderID}" class="nsw-form__group wrth-flex__break<% if $ParentExtraClass %> {$ParentExtraClass}<%end_if %>">
 <% if $FormFieldHint == 'callout' %>
     <%-- render as callout --%>
     <div class="nsw-callout">


### PR DESCRIPTION
## Changes

+ Allow arrangement of composite field child fields into equal width, 2, or 3  columns
+ An HTMLReadonlyField is considered a flex break.
+ Update documentation