### PR TITLE
Add 'Back to top' component

### DIFF
--- a/src/Extensions/PageExtension.php
+++ b/src/Extensions/PageExtension.php
@@ -50,7 +50,8 @@ class PageExtension extends DataExtension
         'ShowBannerImage' => 'Boolean',
         'HideBreadcrumbs' => 'Boolean',
         'DisableLastUpdated' => 'Boolean',
-        'PublicLastUpdated' => 'Date'
+        'PublicLastUpdated' => 'Date',
+        'ShowBackToTop' => 'Boolean'
     ];
 
     /**
@@ -58,7 +59,8 @@ class PageExtension extends DataExtension
      */
     private static $defaults = [
         "ShowAbstractOnPage" => 1,
-        "HideBreadcrumbs" => 0
+        "HideBreadcrumbs" => 0,
+        "ShowBackToTop" => 0
     ];
 
     /**
@@ -220,6 +222,17 @@ class PageExtension extends DataExtension
             $publicLastUpdated
         );
 
+        // Add BackToTop button component
+        $fields->insertBefore(
+            'Visibility',
+            CheckboxField::create(
+                'ShowBackToTop',
+                _t(
+                    'nswds.SHOW_BACK_TO_TOP_BUTTON',
+                    'Include the \'Back to top\' button on the page'
+                )
+            )
+        );
 
     }
 

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/BackToTop.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/BackToTop.ss
@@ -1,0 +1,3 @@
+<% if $Top.ShowBackToTop %>
+<% include nswds/BackToTop %>
+<% end_if %>

--- a/themes/nswds/templates/Page.ss
+++ b/themes/nswds/templates/Page.ss
@@ -35,5 +35,7 @@
 
 <% include NSWDPC/Waratah/GlobalNotice %>
 
+<% include NSWDPC/Waratah/BackToTop %>
+
 </body>
 </html>

--- a/themes/nswds/templates/nswds/Includes/BackToTop.ss
+++ b/themes/nswds/templates/nswds/Includes/BackToTop.ss
@@ -1,0 +1,2 @@
+<button type="button" class="nsw-button nsw-button--<% if $BackToTop_Brand %>{$BackToTop_Brand}<% else %>dark<% end_if %> nsw-button--flex nsw-back-to-top js-back-to-top"<% if $BackToTop_Offset > 0 %> data-offset="{$BackToTop_Offset}"<% end_if %><% if $BackToTop_ScrollElement > 0 %> data-element="{$BackToTop_ScrollElement}"<% end_if %>>
+</button>


### PR DESCRIPTION
## Changes

+ Add 'Back to top' component from nswds. Ref #86
+ Add option in page settings, default off
+ Add form field to settings section
+ Add component template
+ Add include template, can be overridden in themes

The position of the button will interfere with other elements located there (chat bots, captcha badge) but the position can be modified in CSS at a project level, simply:

```css
.nsw-back-to-top {
  // etc
  left: 1rem;// 50%, 75% etc etc
  bottom: 4rem;
}
```

