### PR TITLE
Meta tag updates

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -5,3 +5,6 @@ Page:
   show_last_updated: false
   # date format eg 14 Feb 2001
   last_updated_format: 'dd LLL y'
+SilverStripe\CMS\Model\SiteTree:
+  meta_generator: ''
+  show_meta_generator_version: false

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -6,6 +6,9 @@ Page:
   extensions:
     - 'NSWDPC\Waratah\Extensions\PageExtension'
     - 'NSWDPC\Waratah\Extensions\BreadcrumbExtension'
+SilverStripe\CMS\Model\SiteTree:
+  extensions:
+    - 'NSWDPC\Waratah\Extensions\SiteTreeExtension'
 SilverStripe\ErrorPage\ErrorPage:
   extensions:
     - NSWDPC\Waratah\Extensions\ErrorPageExtension

--- a/src/Extensions/SiteTreeExtension.php
+++ b/src/Extensions/SiteTreeExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NSWDPC\Waratah\Extensions;
+
+use Silverstripe\Control\Controller;
+use Silverstripe\ORM\DataExtension;
+use SilverStripe\Security\Permission;
+use SilverStripe\Versioned\Versioned;
+
+class SiteTreeExtension extends DataExtension
+{
+    /**
+     * Update meta components as required
+     * @param array $tags
+     */
+    public function MetaComponents(array &$tags)
+    {
+
+        // conditionally add these components based on CMS preview mode being in place
+        unset($tags['pageId']);
+        unset($tags['cmsEditLink']);
+        $controller = Controller::curr();
+        $request = $controller->getRequest();
+        if (Permission::check('CMS_ACCESS_CMSMain')
+            && $this->owner->ID > 0
+            && Versioned::get_stage() === Versioned::DRAFT
+            && $request->getVar('CMSPreview') == 1
+        ) {
+            $tags['pageId'] = [
+                'attributes' => [
+                    'name' => 'x-page-id',
+                    'content' => $this->owner->ID,
+                ],
+            ];
+            $tags['cmsEditLink'] = [
+                'attributes' => [
+                    'name' => 'x-cms-edit-link',
+                    'content' => $this->owner->CMSEditLink(),
+                ],
+            ];
+        }
+
+    }
+}

--- a/src/Extensions/SiteTreeExtension.php
+++ b/src/Extensions/SiteTreeExtension.php
@@ -40,5 +40,12 @@ class SiteTreeExtension extends DataExtension
             ];
         }
 
+        $tags['browserViewport'] = [
+            'attributes' => [
+                'name' => 'viewport',
+                'content' => 'width=device-width, initial-scale=1'
+            ]
+        ];
+
     }
 }

--- a/themes/nswds/app/static/site.webmanifest.json
+++ b/themes/nswds/app/static/site.webmanifest.json
@@ -29,6 +29,5 @@
         }
     ],
     "theme_color": "#ffffff",
-    "background_color": "#002664",
-    "start_url": "https://www.dpc.nsw.gov.au"
+    "background_color": "#002664"
 }

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/Metadata.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/Metadata.ss
@@ -1,3 +1,2 @@
 
-<meta name="viewport" content="width=device-width, initial-scale=1">
 {$MetaTags}

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/Metadata.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/Metadata.ss
@@ -1,4 +1,3 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {$MetaTags}
-<link rel="manifest" href="{$resourceURL('nswdpc/waratah:themes/nswds/app/static/site.webmanifest.json')}">

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/Metadata.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/Metadata.ss
@@ -1,18 +1,4 @@
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{$Title.XML} - {$SiteConfig.Title.XML}</title>
-    <% if $Priority == "-1" %><meta name="robots" content="noindex, nofollow"><% end_if %>
-    <% if $MetaDescription || $Abstract %><meta name="description" content="<% if $MetaDescription %>{$MetaDescription.XML}<% else %>{$Abstract.XML}<% end_if %>"><% end_if %>
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="<% if $CurrentPage.InSection(home) %>{$BaseHref}<% else %>{$AbsoluteLink}<% end_if %>">
-    <meta property="og:title" content="{$Title.XML}">
-    <% if $MetaDescription || $Abstract %><meta property="og:description" content="<% if $MetaDescription %>{$MetaDescription.XML}<% else %>{$Abstract.XML}<% end_if %>"><% end_if %>
-    <% if $Image %><meta property="og:image" content="{$Image.FocusFillMax(1200,630).AbsoluteLink}">
-    <meta property="og:image:width" content="1200">
-    <meta property="og:image:height" content="630"><% end_if %>
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:site" content="{$SiteConfig.Title}<% if $SiteConfig.Tagline %> - {$SiteConfig.Tagline}<% end_if %>">
-    <meta name="twitter:url" content="<% if $CurrentPage.InSection(home) %>{$BaseHref}<% else %>{$AbsoluteLink}<% end_if %>">
-    <meta name="twitter:title" content="{$Title.XML}">
-    <% if $MetaDescription || $Abstract %><meta name="twitter:description" content="<% if $MetaDescription %>{$MetaDescription.XML}<% else %>{$Abstract.XML}<% end_if %>"><% end_if %>
-    <% if $Image %><meta name="twitter:image" content="{$Image.FocusFillMax(640,640).AbsoluteLink}"><% end_if %>
-    <link rel="manifest" href="{$resourceURL('nswdpc/waratah:themes/nswds/app/static/site.webmanifest.json')}">
+
+<meta name="viewport" content="width=device-width, initial-scale=1">
+{$MetaTags}
+<link rel="manifest" href="{$resourceURL('nswdpc/waratah:themes/nswds/app/static/site.webmanifest.json')}">

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/Metadata.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/Metadata.ss
@@ -1,5 +1,4 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{$Title.XML} - {$SiteConfig.Title.XML}</title>
     <% if $Priority == "-1" %><meta name="robots" content="noindex, nofollow"><% end_if %>
     <% if $MetaDescription || $Abstract %><meta name="description" content="<% if $MetaDescription %>{$MetaDescription.XML}<% else %>{$Abstract.XML}<% end_if %>"><% end_if %>


### PR DESCRIPTION
## Changes

+ Do not link to a web manifest by default
+ Remove start_url from shipped web manifest
+ Replace manually added meta tags with `{$MetaTags}`
+ Remove unnecessary `X-UA-Compatible` tag
+ Add an extension to conditionally add preview meta tags, when in the relevant preview mode
+ Move viewport to extension
+ Remove generator meta via configuration