### PR TITLE
Decouple search forms from CMS search form

### DIFF
--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/AdvancedSearch.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/AdvancedSearch.ss
@@ -1,0 +1,1 @@
+<% include nswds/FilterForm ClearLink=$CurrentPage.Link %>

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/GlobalSearch.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/GlobalSearch.ss
@@ -3,7 +3,7 @@
 
     <form role="search" {$FormAttributes}>
         <label for="{$FormName}_Search" class="sr-only"><%t nswds.SEARCH_SITE_FOR 'Search site for:' %></label>
-        <input id="{$FormName}_Search" name="Search" autocomplete="off" type="search" class="nsw-header__input js-search-input" value="{$SearchQuery.XML}">
+        <input id="{$FormName}_Search" name="Search" autocomplete="off" type="text" class="nsw-header__input js-search-input" value="{$SearchQuery.XML}">
         <button class="nsw-icon-button nsw-icon-button--flex" type="submit">
             <% include nswds/Icon Icon_Icon='search' %>
             <span class="sr-only"><%t nswds.SEARCH 'Search' %></span>

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/GlobalSearch.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/GlobalSearch.ss
@@ -1,0 +1,23 @@
+<%-- global search implementation - included by nswds/Header --%>
+<div id="header-search" class="nsw-header__search-area js-search-area" hidden>
+
+    <form role="search" {$FormAttributes}>
+        <label for="{$FormName}_Search" class="sr-only"><%t nswds.SEARCH_SITE_FOR 'Search site for:' %></label>
+        <input id="{$FormName}_Search" name="Search" autocomplete="off" type="search" class="nsw-header__input js-search-input" value="{$SearchQuery.XML}">
+        <button class="nsw-icon-button nsw-icon-button--flex" type="submit">
+            <% include nswds/Icon Icon_Icon='search' %>
+            <span class="sr-only"><%t nswds.SEARCH 'Search' %></span>
+        </button>
+        <% if $HiddenFields %>
+            <% loop $HiddenFields %>
+            {$Field}
+            <% end_loop %>
+        <% end_if %>
+    </form>
+
+    <button class="nsw-icon-button js-close-search" aria-expanded="true" aria-controls="header-search">
+        <% include nswds/Icon Icon_Icon='close' %>
+        <span class="sr-only"><%t nswds.CLOSE_SEARCH 'Close search' %></span>
+    </button>
+
+</div>

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/PageSearchResults.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/PageSearchResults.ss
@@ -19,7 +19,7 @@
         <aside class="nsw-layout__sidebar nsw-layout__sidebar--desktop">
             <% if $Form %>
                 <% with $Form %>
-                    <% include SilverStripe/CMS/Search/SearchForm SearchFormContext='wrth-advanced-search' %>
+                    <% include NSWDPC/Waratah/AdvancedSearch %>
                 <% end_with %>
             <% end_if %>
         </aside>
@@ -43,7 +43,7 @@
             <% if $Form %>
                 <% with $Form %>
                     <div class="nsw-m-y-lg">
-                        <% include SilverStripe/CMS/Search/SearchForm SearchFormContext='wrth-simple-search' %>
+                        <% include NSWDPC/Waratah/SimpleSearch %>
                     </div>
                 <% end_with %>
             <% end_if %>

--- a/themes/nswds/templates/NSWDPC/Waratah/Includes/SimpleSearch.ss
+++ b/themes/nswds/templates/NSWDPC/Waratah/Includes/SimpleSearch.ss
@@ -1,0 +1,13 @@
+<%-- single value lookup form --%>
+<form role="search" {$FormAttributes}>
+    <div class="nsw-form__input-group">
+        <label for="{$FormName}_Search" class="sr-only"><%t nswds.SEARCH_SITE_FOR 'Search site for:' %></label>
+        <input id="{$FormName}_Search" name="Search" autocomplete="off" type="search" class="nsw-form__input" value="{$SearchQuery.XML}">
+        <button class="nsw-button nsw-button--dark nsw-button--flex" type="submit"><%t nswds.SEARCH 'Search' %></button>
+    </div>
+    <% if $HiddenFields %>
+        <% loop $HiddenFields %>
+        {$Field}
+        <% end_loop %>
+    <% end_if %>
+</form>

--- a/themes/nswds/templates/SilverStripe/CMS/Search/Includes/SearchForm.ss
+++ b/themes/nswds/templates/SilverStripe/CMS/Search/Includes/SearchForm.ss
@@ -1,49 +1,14 @@
 <% if $SearchFormContext == 'nsw-header-search' %>
 
-    <%-- header search implementation - included by nswds/Header --%>
-    <div id="header-search" class="nsw-header__search-area js-search-area" hidden>
-
-        <form role="search" {$FormAttributes}>
-            <label for="{$FormName}_Search" class="sr-only"><%t nswds.SEARCH_SITE_FOR 'Search site for:' %></label>
-            <input id="{$FormName}_Search" name="Search" autocomplete="off" type="search" class="nsw-header__input js-search-input" value="{$SearchQuery.XML}">
-            <button class="nsw-icon-button nsw-icon-button--flex" type="submit">
-                <% include nswds/Icon Icon_Icon='search' %>
-                <span class="sr-only"><%t nswds.SEARCH 'Search' %></span>
-            </button>
-            <% if $HiddenFields %>
-                <% loop $HiddenFields %>
-                {$Field}
-                <% end_loop %>
-            <% end_if %>
-        </form>
-
-        <button class="nsw-icon-button js-close-search" aria-expanded="true" aria-controls="header-search">
-            <% include nswds/Icon Icon_Icon='close' %>
-            <span class="sr-only"><%t nswds.CLOSE_SEARCH 'Close search' %></span>
-        </button>
-
-    </div>
+    <% include NSWDPC/Waratah/GlobalSearch %>
 
 <% else_if $SearchFormContext == 'wrth-simple-search' %>
 
-    <%-- single value lookup form --%>
-
-    <form role="search" {$FormAttributes}>
-        <div class="nsw-form__input-group">
-            <label for="{$FormName}_Search" class="sr-only"><%t nswds.SEARCH_SITE_FOR 'Search site for:' %></label>
-            <input id="{$FormName}_Search" name="Search" autocomplete="off" type="search" class="nsw-form__input" value="{$SearchQuery.XML}">
-            <button class="nsw-button nsw-button--dark nsw-button--flex" type="submit"><%t nswds.SEARCH 'Search' %></button>
-        </div>
-        <% if $HiddenFields %>
-            <% loop $HiddenFields %>
-            {$Field}
-            <% end_loop %>
-        <% end_if %>
-    </form>
+    <% include NSWDPC/Waratah/SimpleSearch %>
 
 <% else %>
 
     <%-- filter form (e.g SearchFormContext='wrth-advanced-search') --%>
-    <% include nswds/FilterForm ClearLink=$CurrentPage.Link %>
+    <% include NSWDPC/Waratah/AdvancedSearch %>
 
 <% end_if %>

--- a/themes/nswds/templates/nswds/Includes/Header.ss
+++ b/themes/nswds/templates/nswds/Includes/Header.ss
@@ -33,7 +33,7 @@
         <% if $SearchForm %>
 
             <% with $SearchForm %>
-            <% include SilverStripe/CMS/Search/SearchForm SearchFormContext='nsw-header-search' %>
+                <% include NSWDPC/Waratah/GlobalSearch %>
             <% end_with %>
 
         <% end_if %>


### PR DESCRIPTION
## Changes

+ Provide improved options for custom search forms in projects
+ Decouple search form variants from SilverStripe/CMS/Search/SearchForm
+ Include new templates in SearchForm.ss for BC
+ Replace type="search" with type="text" to avoid visual overlap of search icon and 'x' in header search