### PR TITLE
Update nsw-design-system to 3.22.6

### DIFF
--- a/themes/nswds/app/frontend/package-lock.json
+++ b/themes/nswds/app/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "micromodal": "^0.4.10",
-        "nsw-design-system": "^3.22.1",
+        "nsw-design-system": "^3.22.6",
         "slim-select": "^2.10.0"
       },
       "devDependencies": {
@@ -5138,9 +5138,9 @@
       }
     },
     "node_modules/nsw-design-system": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/nsw-design-system/-/nsw-design-system-3.22.1.tgz",
-      "integrity": "sha512-fsuSZ33LwiSOsRr038+VpNJPGxn9G31OxZoW3ZEy/i7dvnVagggAFM+2Jr09npnOVOE6q/Wr54L33HItT60mUg==",
+      "version": "3.22.6",
+      "resolved": "https://registry.npmjs.org/nsw-design-system/-/nsw-design-system-3.22.6.tgz",
+      "integrity": "sha512-ma+YoBAo8Lji4e/5lUyEQ36oSSfe2gF9DVRz814sg5dm9J3EYpArFRUCJdmiifOwBrBMIKw9sNOpLqxyLrqNYA==",
       "dependencies": {
         "@floating-ui/dom": "^1.6.13",
         "vanilla-cookieconsent": "^3.1.0"
@@ -10948,9 +10948,9 @@
       }
     },
     "nsw-design-system": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/nsw-design-system/-/nsw-design-system-3.22.1.tgz",
-      "integrity": "sha512-fsuSZ33LwiSOsRr038+VpNJPGxn9G31OxZoW3ZEy/i7dvnVagggAFM+2Jr09npnOVOE6q/Wr54L33HItT60mUg==",
+      "version": "3.22.6",
+      "resolved": "https://registry.npmjs.org/nsw-design-system/-/nsw-design-system-3.22.6.tgz",
+      "integrity": "sha512-ma+YoBAo8Lji4e/5lUyEQ36oSSfe2gF9DVRz814sg5dm9J3EYpArFRUCJdmiifOwBrBMIKw9sNOpLqxyLrqNYA==",
       "requires": {
         "@floating-ui/dom": "^1.6.13",
         "vanilla-cookieconsent": "^3.1.0"

--- a/themes/nswds/app/frontend/package.json
+++ b/themes/nswds/app/frontend/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "micromodal": "^0.4.10",
-    "nsw-design-system": "^3.22.1",
+    "nsw-design-system": "^3.22.6",
     "slim-select": "^2.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Changes

+ Update nsw-design-system to 3.22.6

Note feature added to card in 3.22.2 (https://github.com/digitalnsw/nsw-design-system/blob/master/CHANGELOG.md) that we could support - adding border option to card `nsw-card--border`

Changelog: https://github.com/digitalnsw/nsw-design-system/compare/v3.22.1...v3.22.6

+ `@use '../../global/scss/tools' as nsw;` - updated usage (see src/components/accordion/_accordion.scss change for example)